### PR TITLE
Add custom error type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ doc/api/
 
 # IDEs
 .idea/
+
+# Test coverage
+coverage/
+
+# Other
+.fvm/

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -57,6 +57,7 @@ class TelemetryClient {
     StackTrace? stackTrace,
     String? problemId,
     Map<String, Object> additionalProperties = const <String, Object>{},
+    String? customErrorType,
     DateTime? timestamp,
   }) =>
       _track(
@@ -67,6 +68,7 @@ class TelemetryClient {
           problemId: problemId,
           additionalProperties: additionalProperties,
           timestamp: timestamp,
+          customErrorType: customErrorType,
         ),
       );
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   http: '>=0.13.6 <2.0.0'
   logging: ^1.2.0
   meta: ^1.9.1
-  stack_trace: ^1.11.1
+  stack_trace: ^1.11.0
 
 dev_dependencies:
   build_runner: ^2.4.6

--- a/scripts/postinstall_macos.sh
+++ b/scripts/postinstall_macos.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+echo 'Installing infrastructure libraries...' && \
+
+brew install lcov && \
+dart pub global activate coverage

--- a/scripts/test_coverage.sh
+++ b/scripts/test_coverage.sh
@@ -4,6 +4,7 @@ set -e
 
 echo 'Starting test coverage...' && \
 
+dart run build_runner build --delete-conflicting-outputs && \
 dart test --coverage=coverage && \
 format_coverage --lcov --in=coverage --out=coverage/lcov.info --report-on=lib && \
 lcov --remove coverage/lcov.info -o coverage/lcov-full.info --ignore-errors unused && \

--- a/scripts/test_coverage.sh
+++ b/scripts/test_coverage.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+echo 'Starting test coverage...' && \
+
+dart test --coverage=coverage && \
+format_coverage --lcov --in=coverage --out=coverage/lcov.info --report-on=lib && \
+lcov --remove coverage/lcov.info -o coverage/lcov-full.info --ignore-errors unused && \
+genhtml coverage/lcov-full.info -o coverage && \
+open coverage/index.html

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -85,6 +85,41 @@ void _trackError() {
           );
         },
       );
+
+      test(
+        'creates exception telemetry with the custom error and forwards to processor',
+        () {
+          final processor = MockProcessor();
+          final sut = TelemetryClient(processor: processor);
+          sut.trackError(
+              severity: Severity.critical,
+              error: 'an error',
+              customErrorType: 'CustomStringError');
+
+          expect(
+            verify(processor.process(
+                    contextualTelemetryItems:
+                        captureAnyNamed('contextualTelemetryItems')))
+                .captured
+                .single,
+            predicate<List<ContextualTelemetryItem>>((v) {
+              if (v.length != 1) {
+                return false;
+              }
+
+              final telemetry = v[0].telemetryItem;
+
+              if (telemetry is ExceptionTelemetryItem) {
+                return telemetry.severity == Severity.critical &&
+                    telemetry.error == 'an error' &&
+                    telemetry.customErrorType == 'CustomStringError';
+              }
+
+              return false;
+            }),
+          );
+        },
+      );
     },
   );
 }

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -178,6 +178,7 @@ class MockTelemetryClient extends _i1.Mock implements _i7.TelemetryClient {
     StackTrace? stackTrace,
     String? problemId,
     Map<String, Object>? additionalProperties = const {},
+    String? customErrorType,
     DateTime? timestamp,
   }) =>
       super.noSuchMethod(
@@ -190,6 +191,7 @@ class MockTelemetryClient extends _i1.Mock implements _i7.TelemetryClient {
             #stackTrace: stackTrace,
             #problemId: problemId,
             #additionalProperties: additionalProperties,
+            #customErrorType: customErrorType,
             #timestamp: timestamp,
           },
         ),

--- a/test/telemetry_test.dart
+++ b/test/telemetry_test.dart
@@ -120,6 +120,20 @@ void _exceptionTelemetry() {
             expectedJson:
                 '{"baseType":"ExceptionData","baseData":{"ver":2,"severityLevel":4,"exceptions":[{"typeName":"String","message":"an error with properties","hasFullStack":false}],"problemId":"dc7b331564ab7acc456aee1c10e54adc8c710977","properties":{"foo":"bar","another":1}}}',
           );
+
+          _verifyDataMap(
+            telemetry: ExceptionTelemetryItem(
+              severity: Severity.critical,
+              error: 'an error with properties',
+              customErrorType: 'CustomStringError',
+              additionalProperties: const <String, Object>{
+                'another': 1,
+              },
+            ),
+            context: TelemetryContext()..properties['foo'] = 'bar',
+            expectedJson:
+                '{"baseType":"ExceptionData","baseData":{"ver":2,"severityLevel":4,"exceptions":[{"typeName":"CustomStringError","message":"an error with properties","hasFullStack":false}],"problemId":"dc7b331564ab7acc456aee1c10e54adc8c710977","properties":{"foo":"bar","another":1}}}',
+          );
         },
       );
     },


### PR DESCRIPTION
What has been done:
- added "customErrorType" field: we've added a new field called "customErrorType" to the ExceptionTelemetryItem. This is useful for cases where the regular "error" field doesn't quite fit.
- postinstall script: we've put in a script that can be run after the installation, which will help to set up the system more smoothly
- test_coderage script: there's now a script for checking test coverage, which helps us make sure everything is tested properly